### PR TITLE
Wip/ptr

### DIFF
--- a/sal/list.cmake
+++ b/sal/list.cmake
@@ -13,6 +13,7 @@ list(APPEND sal_sources
   sal/__bits/intrusive_queue.hpp
   sal/lockable.hpp
   sal/memory_writer.hpp
+  sal/ptr.hpp
   sal/queue.hpp
   sal/__bits/queue.hpp
   sal/spinlock.hpp
@@ -35,6 +36,7 @@ list(APPEND sal_unittests
   sal/intrusive_queue.test.cpp
   sal/lockable.test.cpp
   sal/memory_writer.test.cpp
+  sal/ptr.test.cpp
   sal/queue.test.cpp
   sal/spinlock.test.cpp
   sal/thread.test.cpp

--- a/sal/net/__bits/platform.cpp
+++ b/sal/net/__bits/platform.cpp
@@ -449,7 +449,7 @@ void remote_endpoint (native_handle_t handle,
 
 
 size_t recv_from (native_handle_t handle,
-  char *data, size_t data_size,
+  void *data, size_t data_size,
   void *address, size_t *address_size,
   int flags,
   std::error_code &error) noexcept
@@ -458,7 +458,7 @@ size_t recv_from (native_handle_t handle,
 
   auto _address_size = static_cast<socklen_t>(*address_size);
   auto size = ::recvfrom(handle,
-    data, static_cast<int>(data_size),
+    static_cast<char *>(data), static_cast<int>(data_size),
     flags,
     static_cast<sockaddr *>(address), (address ? &_address_size : nullptr)
   );
@@ -513,7 +513,7 @@ size_t recv_from (native_handle_t handle,
 
 
 size_t send_to (native_handle_t handle,
-  const char *data, size_t data_size,
+  const void *data, size_t data_size,
   const void *address, size_t address_size,
   int flags,
   std::error_code &error) noexcept
@@ -521,7 +521,7 @@ size_t send_to (native_handle_t handle,
 #if __sal_os_windows
 
   auto size = ::sendto(handle,
-    data, static_cast<int>(data_size),
+    static_cast<const char *>(data), static_cast<int>(data_size),
     flags,
     static_cast<const sockaddr *>(address), static_cast<socklen_t>(address_size)
   );
@@ -539,7 +539,7 @@ size_t send_to (native_handle_t handle,
 #else
 
   iovec iov;
-  iov.iov_base = const_cast<char *>(data);
+  iov.iov_base = const_cast<void *>(data);
   iov.iov_len = data_size;
 
   msghdr msg;
@@ -564,13 +564,16 @@ size_t send_to (native_handle_t handle,
 
 
 size_t recv (native_handle_t handle,
-  char *data, size_t data_size,
+  void *data, size_t data_size,
   int flags,
   std::error_code &error) noexcept
 {
 #if __sal_os_windows
 
-  auto size = ::recv(handle, data, static_cast<int>(data_size), flags);
+  auto size = ::recv(handle,
+    static_cast<char *>(data), static_cast<int>(data_size),
+    flags
+  );
 
   if (size == -1 && ::WSAGetLastError() == WSAESHUTDOWN)
   {
@@ -611,13 +614,16 @@ size_t recv (native_handle_t handle,
 
 
 size_t send (native_handle_t handle,
-  const char *data, size_t data_size,
+  const void *data, size_t data_size,
   int flags,
   std::error_code &error) noexcept
 {
 #if __sal_os_windows
 
-  auto size = ::send(handle, data, static_cast<int>(data_size), flags);
+  auto size = ::send(handle,
+    static_cast<const char *>(data), static_cast<int>(data_size),
+    flags
+  );
 
   if (size == -1 && ::WSAGetLastError() == WSAESHUTDOWN)
   {
@@ -629,7 +635,7 @@ size_t send (native_handle_t handle,
 #else
 
   iovec iov;
-  iov.iov_base = const_cast<char *>(data);
+  iov.iov_base = const_cast<void *>(data);
   iov.iov_len = data_size;
 
   msghdr msg;

--- a/sal/net/__bits/platform.hpp
+++ b/sal/net/__bits/platform.hpp
@@ -123,27 +123,27 @@ void remote_endpoint (native_handle_t handle,
 ) noexcept;
 
 size_t recv_from (native_handle_t handle,
-  char *data, size_t data_size,
+  void *data, size_t data_size,
   void *address, size_t *address_size,
   int flags,
   std::error_code &error
 ) noexcept;
 
 size_t send_to (native_handle_t handle,
-  const char *data, size_t data_size,
+  const void *data, size_t data_size,
   const void *address, size_t address_size,
   int flags,
   std::error_code &error
 ) noexcept;
 
 size_t recv (native_handle_t handle,
-  char *data, size_t data_size,
+  void *data, size_t data_size,
   int flags,
   std::error_code &error
 ) noexcept;
 
 size_t send (native_handle_t handle,
-  const char *data, size_t data_size,
+  const void *data, size_t data_size,
   int flags,
   std::error_code &error
 ) noexcept;

--- a/sal/net/basic_datagram_socket.hpp
+++ b/sal/net/basic_datagram_socket.hpp
@@ -9,6 +9,7 @@
 #include <sal/config.hpp>
 #include <sal/net/fwd.hpp>
 #include <sal/net/basic_socket.hpp>
+#include <sal/ptr.hpp>
 
 
 __sal_begin
@@ -89,18 +90,19 @@ public:
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received and stores sender address into \a endpoint.
-   * On failure, set \a error and return 0.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received and stores sender address into \a endpoint. On failure,
+   * set \a error and return 0.
    */
-  size_t receive_from (char *data, size_t size,
+  template <typename Ptr>
+  size_t receive_from (const Ptr &buf,
     endpoint_t &endpoint,
     socket_base_t::message_flags_t flags,
     std::error_code &error) noexcept
   {
-    size_t endpoint_size = endpoint.capacity();
-    size = __bits::recv_from(base_t::native_handle(),
-      data, size,
+    auto endpoint_size = endpoint.capacity();
+    auto size = __bits::recv_from(base_t::native_handle(),
+      buf.get(), buf.size(),
       endpoint.data(), &endpoint_size,
       static_cast<int>(flags),
       error
@@ -114,120 +116,114 @@ public:
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received and stores sender address into \a endpoint.
-   * On failure, throw std::system_error.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received and stores sender address into \a endpoint. On failure,
+   * throw std::system_error.
    */
-  size_t receive_from (char *data, size_t max_size,
+  template <typename Ptr>
+  size_t receive_from (const Ptr &buf,
     endpoint_t &endpoint,
     socket_base_t::message_flags_t flags)
   {
-    return receive_from(data, max_size,
-      endpoint, flags,
+    return receive_from(buf, endpoint, flags,
       throw_on_error("basic_datagram_socket::receive_from")
     );
   }
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received and stores sender address into \a endpoint.
-   * On failure, set \a error and return 0.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received and stores sender address into \a endpoint. On failure,
+   * set \a error and return 0.
    */
-  size_t receive_from (char *data, size_t max_size,
+  template <typename Ptr>
+  size_t receive_from (const Ptr &buf,
     endpoint_t &endpoint,
     std::error_code &error) noexcept
   {
-    return receive_from(data, max_size,
-      endpoint, socket_base_t::message_flags_t{},
-      error
-    );
+    return receive_from(buf, endpoint, socket_base_t::message_flags_t{}, error);
   }
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received and stores sender address into \a endpoint.
-   * On failure, throw std::system_error.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received and stores sender address into \a endpoint. On failure,
+   * throw std::system_error.
    */
-  size_t receive_from (char *data, size_t max_size, endpoint_t &endpoint)
+  template <typename Ptr>
+  size_t receive_from (const Ptr &buf, endpoint_t &endpoint)
   {
-    return receive_from(data, max_size, endpoint,
+    return receive_from(buf, endpoint,
       throw_on_error("basic_datagram_socket::receive_from")
     );
   }
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, set \a error and return 0.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, set \a error and return 0.
    */
-  size_t receive (char *data, size_t size,
+  template <typename Ptr>
+  size_t receive (const Ptr &buf,
     socket_base_t::message_flags_t flags,
     std::error_code &error) noexcept
   {
     size_t endpoint_size = 0;
-    size = __bits::recv_from(base_t::native_handle(),
-      data, size,
+    return __bits::recv_from(base_t::native_handle(),
+      buf.get(), buf.size(),
       nullptr, &endpoint_size,
       static_cast<int>(flags),
       error
     );
-    return size;
   }
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, throw std::system_error
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, throw std::system_error
    */
-  size_t receive (char *data, size_t max_size,
-    socket_base_t::message_flags_t flags)
+  template <typename Ptr>
+  size_t receive (const Ptr &buf, socket_base_t::message_flags_t flags)
   {
-    return receive(data, max_size, flags,
-      throw_on_error("basic_datagram_socket::receive")
-    );
+    return receive(buf, flags, throw_on_error("basic_datagram_socket::receive"));
   }
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, set \a error and return 0.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, set \a error and return 0.
    */
-  size_t receive (char *data, size_t max_size,
-    std::error_code &error) noexcept
+  template <typename Ptr>
+  size_t receive (const Ptr &buf, std::error_code &error) noexcept
   {
-    return receive(data, max_size,
-      socket_base_t::message_flags_t{},
-      error
-    );
+    return receive(buf, socket_base_t::message_flags_t{}, error);
   }
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, throw std::system_error
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, throw std::system_error
    */
-  size_t receive (char *data, size_t max_size)
+  template <typename Ptr>
+  size_t receive (const Ptr &buf)
   {
-    return receive(data, max_size,
-      throw_on_error("basic_datagram_socket::receive")
-    );
+    return receive(buf, throw_on_error("basic_datagram_socket::receive"));
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * \a endpoint. On success, returns number of bytes sent. On failure, set
-   * \a error and return 0.
+   * Write data of \a buf into this socket for delivering to \a endpoint. On
+   * success, returns number of bytes sent. On failure, set \a error and
+   * return 0.
    */
-  size_t send_to (const char *data, size_t size,
+  template <typename Ptr>
+  size_t send_to (const Ptr &buf,
     const endpoint_t &endpoint,
     socket_base_t::message_flags_t flags,
     std::error_code &error) noexcept
   {
     return __bits::send_to(base_t::native_handle(),
-      data, size,
+      buf.get(), buf.size(),
       endpoint.data(), endpoint.size(),
       static_cast<int>(flags),
       error
@@ -236,61 +232,61 @@ public:
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * \a endpoint. On success, returns number of bytes sent. On failure, throw
+   * Write daa of \a buf into this socket for delivering to \a endpoint. On
+   * success, returns number of bytes sent. On failure, throw
    * std::system_error
    */
-  size_t send_to (const char *data, size_t size,
+  template <typename Ptr>
+  size_t send_to (const Ptr &buf,
     const endpoint_t &endpoint,
     socket_base_t::message_flags_t flags)
   {
-    return send_to(data, size, endpoint, flags,
+    return send_to(buf, endpoint, flags,
       throw_on_error("basic_datagram_socket::send_to")
     );
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * \a endpoint. On success, returns number of bytes sent. On failure, set
-   * \a error and return 0.
+   * Write data of \a buf into this socket for delivering to \a endpoint. On
+   * success, returns number of bytes sent. On failure, set \a error and
+   * return 0.
    */
-  size_t send_to (const char *data, size_t size,
+  template <typename Ptr>
+  size_t send_to (const Ptr &buf,
     const endpoint_t &endpoint,
     std::error_code &error) noexcept
   {
-    return send_to(data, size, endpoint,
-      socket_base_t::message_flags_t{},
-      error
-    );
+    return send_to(buf, endpoint, socket_base_t::message_flags_t{}, error);
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * \a endpoint. On success, returns number of bytes sent. On failure, throw
+   * Write data of \a buf into this socket for delivering to \a endpoint. On
+   * success, returns number of bytes sent. On failure, throw
    * std::system_error
    */
-  size_t send_to (const char *data, size_t size,
-    const endpoint_t &endpoint)
+  template <typename Ptr>
+  size_t send_to (const Ptr &buf, const endpoint_t &endpoint)
   {
-    return send_to(data, size, endpoint,
+    return send_to(buf, endpoint,
       throw_on_error("basic_datagram_socket::send_to")
     );
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * set \a error and return 0.
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, set
+   * \a error and return 0.
    */
-  size_t send (const char *data, size_t size,
+  template <typename Ptr>
+  size_t send (const Ptr &buf,
     socket_base_t::message_flags_t flags,
     std::error_code &error) noexcept
   {
     return __bits::send_to(base_t::native_handle(),
-      data, size,
+      buf.get(), buf.size(),
       nullptr, 0,
       static_cast<int>(flags),
       error
@@ -299,38 +295,38 @@ public:
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * throw std::system_error
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, throw
+   * std::system_error
    */
-  size_t send (const char *data, size_t size,
-    socket_base_t::message_flags_t flags)
+  template <typename Ptr>
+  size_t send (const Ptr &buf, socket_base_t::message_flags_t flags)
   {
-    return send(data, size, flags,
-      throw_on_error("basic_datagram_socket::send")
-    );
+    return send(buf, flags, throw_on_error("basic_datagram_socket::send"));
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * set \a error and return 0.
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, set
+   * \a error and return 0.
    */
-  size_t send (const char *data, size_t size, std::error_code &error) noexcept
+  template <typename Ptr>
+  size_t send (const Ptr &buf, std::error_code &error) noexcept
   {
-    return send(data, size, socket_base_t::message_flags_t{}, error);
+    return send(buf, socket_base_t::message_flags_t{}, error);
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * throw std::system_error
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, throw
+   * std::system_error
    */
-  size_t send (const char *data, size_t size)
+  template <typename Ptr>
+  size_t send (const Ptr &buf)
   {
-    return send(data, size, throw_on_error("basic_datagram_socket::send"));
+    return send(buf, throw_on_error("basic_datagram_socket::send"));
   }
 };
 

--- a/sal/net/basic_stream_socket.hpp
+++ b/sal/net/basic_stream_socket.hpp
@@ -9,6 +9,7 @@
 #include <sal/config.hpp>
 #include <sal/net/fwd.hpp>
 #include <sal/net/basic_socket.hpp>
+#include <sal/ptr.hpp>
 
 
 __sal_begin
@@ -89,107 +90,106 @@ public:
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, set \a error and return 0.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, set \a error and return 0.
    */
-  size_t receive (char *data, size_t size,
+  template <typename Ptr>
+  size_t receive (const Ptr &buf,
     socket_base_t::message_flags_t flags,
     std::error_code &error) noexcept
   {
-    size = __bits::recv(base_t::native_handle(),
-      data, size, static_cast<int>(flags), error
-    );
-    return size;
-  }
-
-
-  /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, throw std::system_error
-   */
-  size_t receive (char *data, size_t max_size,
-    socket_base_t::message_flags_t flags)
-  {
-    return receive(data, max_size, flags,
-      throw_on_error("basic_stream_socket::receive")
-    );
-  }
-
-
-  /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, set \a error and return 0.
-   */
-  size_t receive (char *data, size_t max_size,
-    std::error_code &error) noexcept
-  {
-    return receive(data, max_size,
-      socket_base_t::message_flags_t{},
+    return __bits::recv(base_t::native_handle(),
+      buf.get(), buf.size(),
+      static_cast<int>(flags),
       error
     );
   }
 
 
   /**
-   * Receive data (up to \a size bytes) from this socket. On success, returns
-   * number of bytes received. On failure, throw std::system_error
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, throw std::system_error
    */
-  size_t receive (char *data, size_t max_size)
+  template <typename Ptr>
+  size_t receive (const Ptr &buf, socket_base_t::message_flags_t flags)
   {
-    return receive(data, max_size,
-      throw_on_error("basic_stream_socket::receive")
-    );
+    return receive(buf, flags, throw_on_error("basic_stream_socket::receive"));
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * set \a error and return 0.
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, set \a error and return 0.
    */
-  size_t send (const char *data, size_t size,
+  template <typename Ptr>
+  size_t receive (const Ptr &buf, std::error_code &error) noexcept
+  {
+    return receive(buf, socket_base_t::message_flags_t{}, error);
+  }
+
+
+  /**
+   * Receive data from this socket into \a buf. On success, returns number of
+   * bytes received. On failure, throw std::system_error
+   */
+  template <typename Ptr>
+  size_t receive (const Ptr &buf)
+  {
+    return receive(buf, throw_on_error("basic_stream_socket::receive"));
+  }
+
+
+  /**
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, set
+   * \a error and return 0.
+   */
+  template <typename Ptr>
+  size_t send (const Ptr &buf,
     socket_base_t::message_flags_t flags,
     std::error_code &error) noexcept
   {
     return __bits::send(base_t::native_handle(),
-      data, size, static_cast<int>(flags), error
+      buf.get(), buf.size(),
+      static_cast<int>(flags),
+      error
     );
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * throw std::system_error
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, throw
+   * std::system_error
    */
-  size_t send (const char *data, size_t size,
-    socket_base_t::message_flags_t flags)
+  template <typename Ptr>
+  size_t send (const Ptr &buf, socket_base_t::message_flags_t flags)
   {
-    return send(data, size, flags,
-      throw_on_error("basic_stream_socket::send")
-    );
+    return send(buf, flags, throw_on_error("basic_stream_socket::send"));
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * set \a error and return 0.
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, set
+   * \a error and return 0.
    */
-  size_t send (const char *data, size_t size, std::error_code &error) noexcept
+  template <typename Ptr>
+  size_t send (const Ptr &buf, std::error_code &error) noexcept
   {
-    return send(data, size, socket_base_t::message_flags_t{}, error);
+    return send(buf, socket_base_t::message_flags_t{}, error);
   }
 
 
   /**
-   * Write \a size bytes of \a data into this socket for delivering to
-   * connected endpoint. On success, returns number of bytes sent. On failure,
-   * throw std::system_error
+   * Write data of \a buf into this socket for delivering to connected
+   * endpoint. On success, returns number of bytes sent. On failure, throw
+   * std::system_error
    */
-  size_t send (const char *data, size_t size)
+  template <typename Ptr>
+  size_t send (const Ptr &buf)
   {
-    return send(data, size, throw_on_error("basic_stream_socket::send"));
+    return send(buf, throw_on_error("basic_stream_socket::send"));
   }
 };
 

--- a/sal/net/ip/datagram_socket.test.cpp
+++ b/sal/net/ip/datagram_socket.test.cpp
@@ -110,13 +110,13 @@ TEST_P(datagram_socket, receive_from_invalid)
 
   {
     std::error_code error;
-    EXPECT_EQ(0U, socket.receive_from(buf, sizeof(buf), endpoint, error));
+    EXPECT_EQ(0U, socket.receive_from(sal::ptr(buf), endpoint, error));
     EXPECT_EQ(std::errc::bad_file_descriptor, error);
   }
 
   {
     EXPECT_THROW(
-      (void)socket.receive_from(buf, sizeof(buf), endpoint),
+      (void)socket.receive_from(sal::ptr(buf), endpoint),
       std::system_error
     );
   }
@@ -133,13 +133,13 @@ TEST_P(datagram_socket, receive_from_no_sender_non_blocking)
 
   {
     std::error_code error;
-    EXPECT_EQ(0U, socket.receive_from(buf, sizeof(buf), endpoint, error));
+    EXPECT_EQ(0U, socket.receive_from(sal::ptr(buf), endpoint, error));
     EXPECT_EQ(std::errc::operation_would_block, error);
   }
 
   {
     EXPECT_THROW(
-      (void)socket.receive_from(buf, sizeof(buf), endpoint),
+      (void)socket.receive_from(sal::ptr(buf), endpoint),
       std::system_error
     );
   }
@@ -153,15 +153,13 @@ TEST_P(datagram_socket, send_to_invalid)
 
   {
     std::error_code error;
-    EXPECT_EQ(0U,
-      socket.send_to(case_name.data(), case_name.size(), endpoint, error)
-    );
+    EXPECT_EQ(0U, socket.send_to(sal::ptr(case_name), endpoint, error));
     EXPECT_EQ(std::errc::bad_file_descriptor, error);
   }
 
   {
     EXPECT_THROW(
-      (void)socket.send_to(case_name.data(), case_name.size(), endpoint),
+      (void)socket.send_to(sal::ptr(case_name), endpoint),
       std::system_error
     );
   }
@@ -179,10 +177,7 @@ TEST_P(datagram_socket, send_to_and_receive_from)
 
   // sender
   {
-    EXPECT_EQ(
-      case_name.size(),
-      s.send_to(case_name.c_str(), case_name.size(), ra)
-    );
+    EXPECT_EQ(case_name.size(), s.send_to(sal::ptr(case_name), ra));
   }
 
   ASSERT_TRUE(r.wait(r.wait_read, 10s));
@@ -192,10 +187,7 @@ TEST_P(datagram_socket, send_to_and_receive_from)
     socket_t::endpoint_t endpoint;
     char buf[1024];
     std::memset(buf, '\0', sizeof(buf));
-    EXPECT_EQ(
-      case_name.size(),
-      r.receive_from(buf, sizeof(buf), endpoint)
-    );
+    EXPECT_EQ(case_name.size(), r.receive_from(sal::ptr(buf), endpoint));
     EXPECT_EQ(buf, case_name);
     EXPECT_EQ(sa, endpoint);
   }
@@ -213,10 +205,7 @@ TEST_P(datagram_socket, receive_from_less_than_send_to)
 
   // sender
   {
-    EXPECT_EQ(
-      case_name.size(),
-      s.send_to(case_name.c_str(), case_name.size(), ra)
-    );
+    EXPECT_EQ(case_name.size(), s.send_to(sal::ptr(case_name), ra));
   }
 
   ASSERT_TRUE(r.wait(r.wait_read, 10s));
@@ -227,7 +216,9 @@ TEST_P(datagram_socket, receive_from_less_than_send_to)
     socket_t::endpoint_t endpoint;
     char buf[1024];
     std::memset(buf, '\0', sizeof(buf));
-    EXPECT_EQ(0U, r.receive_from(buf, case_name.size() / 2, endpoint, error));
+    EXPECT_EQ(0U,
+      r.receive_from(sal::ptr(buf, case_name.size() / 2), endpoint, error)
+    );
     EXPECT_EQ(std::errc::message_size, error);
     EXPECT_FALSE(r.wait(r.wait_read, 0s));
   }
@@ -242,29 +233,20 @@ TEST_P(datagram_socket, receive_from_peek)
   socket_t r(ra), s(sa);
 
   // sender
-  EXPECT_EQ(
-    case_name.size(),
-    s.send_to(case_name.c_str(), case_name.size(), ra)
-  );
+  EXPECT_EQ(case_name.size(), s.send_to(sal::ptr(case_name), ra));
 
   socket_t::endpoint_t endpoint;
   char buf[1024];
 
   // receiver: peek
   std::memset(buf, '\0', sizeof(buf));
-  EXPECT_EQ(
-    case_name.size(),
-    r.receive_from(buf, sizeof(buf), endpoint, r.peek)
-  );
+  EXPECT_EQ(case_name.size(), r.receive_from(sal::ptr(buf), endpoint, r.peek));
   EXPECT_EQ(buf, case_name);
   EXPECT_EQ(sa, endpoint);
 
   // receiver: actually extract
   std::memset(buf, '\0', sizeof(buf));
-  EXPECT_EQ(
-    case_name.size(),
-    r.receive_from(buf, sizeof(buf), endpoint)
-  );
+  EXPECT_EQ(case_name.size(), r.receive_from(sal::ptr(buf), endpoint));
   EXPECT_EQ(buf, case_name);
   EXPECT_EQ(sa, endpoint);
 }
@@ -280,7 +262,7 @@ TEST_P(datagram_socket, send_to_do_not_route)
   // sender
   EXPECT_EQ(
     case_name.size(),
-    s.send_to(case_name.c_str(), case_name.size(), ra, s.do_not_route)
+    s.send_to(sal::ptr(case_name), ra, s.do_not_route)
   );
 
   socket_t::endpoint_t endpoint;
@@ -288,10 +270,7 @@ TEST_P(datagram_socket, send_to_do_not_route)
   std::memset(buf, '\0', sizeof(buf));
 
   // receiver
-  EXPECT_EQ(
-    case_name.size(),
-    r.receive_from(buf, sizeof(buf), endpoint)
-  );
+  EXPECT_EQ(case_name.size(), r.receive_from(sal::ptr(buf), endpoint));
   EXPECT_EQ(buf, case_name);
   EXPECT_EQ(sa, endpoint);
 }
@@ -305,13 +284,13 @@ TEST_P(datagram_socket, receive_invalid)
 
   {
     std::error_code error;
-    EXPECT_EQ(0U, socket.receive(buf, sizeof(buf), error));
+    EXPECT_EQ(0U, socket.receive(sal::ptr(buf), error));
     EXPECT_EQ(std::errc::bad_file_descriptor, error);
   }
 
   {
     EXPECT_THROW(
-      (void)socket.receive(buf, sizeof(buf)),
+      (void)socket.receive(sal::ptr(buf)),
       std::system_error
     );
   }
@@ -328,13 +307,13 @@ TEST_P(datagram_socket, receive_no_sender_non_blocking)
 
   {
     std::error_code error;
-    EXPECT_EQ(0U, socket.receive(buf, sizeof(buf), error));
+    EXPECT_EQ(0U, socket.receive(sal::ptr(buf), error));
     EXPECT_EQ(std::errc::operation_would_block, error);
   }
 
   {
     EXPECT_THROW(
-      (void)socket.receive(buf, sizeof(buf)),
+      (void)socket.receive(sal::ptr(buf)),
       std::system_error
     );
   }
@@ -347,13 +326,13 @@ TEST_P(datagram_socket, send_invalid)
 
   {
     std::error_code error;
-    EXPECT_EQ(0U, socket.send(case_name.data(), case_name.size(), error));
+    EXPECT_EQ(0U, socket.send(sal::ptr(case_name), error));
     EXPECT_EQ(std::errc::bad_file_descriptor, error);
   }
 
   {
     EXPECT_THROW(
-      (void)socket.send(case_name.data(), case_name.size()),
+      (void)socket.send(sal::ptr(case_name)),
       std::system_error
     );
   }
@@ -366,15 +345,12 @@ TEST_P(datagram_socket, send_not_connected)
 
   {
     std::error_code error;
-    socket.send(case_name.c_str(), case_name.size(), error);
+    socket.send(sal::ptr(case_name), error);
     EXPECT_EQ(std::errc::destination_address_required, error);
   }
 
   {
-    EXPECT_THROW(
-      socket.send(case_name.c_str(), case_name.size()),
-      std::system_error
-    );
+    EXPECT_THROW(socket.send(sal::ptr(case_name)), std::system_error);
   }
 }
 
@@ -391,7 +367,7 @@ TEST_P(datagram_socket, send_and_receive)
   // sender
   {
     ASSERT_NO_THROW(s.connect(ra));
-    EXPECT_EQ(case_name.size(), s.send(case_name.c_str(), case_name.size()));
+    EXPECT_EQ(case_name.size(), s.send(sal::ptr(case_name)));
   }
 
   ASSERT_TRUE(r.wait(r.wait_read, 10s));
@@ -400,7 +376,7 @@ TEST_P(datagram_socket, send_and_receive)
   {
     char buf[1024];
     std::memset(buf, '\0', sizeof(buf));
-    EXPECT_EQ(case_name.size(), r.receive(buf, sizeof(buf)));
+    EXPECT_EQ(case_name.size(), r.receive(sal::ptr(buf)));
     EXPECT_EQ(buf, case_name);
   }
 }
@@ -418,7 +394,7 @@ TEST_P(datagram_socket, receive_less_than_send)
   // sender
   {
     ASSERT_NO_THROW(s.connect(ra));
-    EXPECT_EQ(case_name.size(), s.send(case_name.c_str(), case_name.size()));
+    EXPECT_EQ(case_name.size(), s.send(sal::ptr(case_name)));
   }
 
   ASSERT_TRUE(r.wait(r.wait_read, 10s));
@@ -428,7 +404,7 @@ TEST_P(datagram_socket, receive_less_than_send)
     std::error_code error;
     char buf[1024];
     std::memset(buf, '\0', sizeof(buf));
-    EXPECT_EQ(0U, r.receive(buf, case_name.size() / 2, error));
+    EXPECT_EQ(0U, r.receive(sal::ptr(buf, case_name.size() / 2), error));
     EXPECT_EQ(std::errc::message_size, error);
     EXPECT_FALSE(r.wait(r.wait_read, 0s));
   }
@@ -444,18 +420,18 @@ TEST_P(datagram_socket, receive_peek)
 
   // sender
   ASSERT_NO_THROW(s.connect(ra));
-  EXPECT_EQ(case_name.size(), s.send(case_name.c_str(), case_name.size()));
+  EXPECT_EQ(case_name.size(), s.send(sal::ptr(case_name)));
 
   char buf[1024];
 
   // receiver: peek
   std::memset(buf, '\0', sizeof(buf));
-  EXPECT_EQ(case_name.size(), r.receive(buf, sizeof(buf), r.peek));
+  EXPECT_EQ(case_name.size(), r.receive(sal::ptr(buf), r.peek));
   EXPECT_EQ(buf, case_name);
 
   // receiver: actually extract
   std::memset(buf, '\0', sizeof(buf));
-  EXPECT_EQ(case_name.size(), r.receive(buf, sizeof(buf)));
+  EXPECT_EQ(case_name.size(), r.receive(sal::ptr(buf)));
   EXPECT_EQ(buf, case_name);
 }
 
@@ -471,7 +447,7 @@ TEST_P(datagram_socket, send_do_not_route)
   ASSERT_NO_THROW(s.connect(ra));
   EXPECT_EQ(
     case_name.size(),
-    s.send(case_name.c_str(), case_name.size(), s.do_not_route)
+    s.send(sal::ptr(case_name), s.do_not_route)
   );
 
   socket_t::endpoint_t endpoint;
@@ -479,7 +455,7 @@ TEST_P(datagram_socket, send_do_not_route)
   std::memset(buf, '\0', sizeof(buf));
 
   // receiver
-  EXPECT_EQ(case_name.size(), r.receive(buf, sizeof(buf)));
+  EXPECT_EQ(case_name.size(), r.receive(sal::ptr(buf)));
   EXPECT_EQ(buf, case_name);
 }
 

--- a/sal/ptr.hpp
+++ b/sal/ptr.hpp
@@ -1,0 +1,422 @@
+#pragma once
+
+/**
+ * \file sal/ptr.hpp
+ */
+
+#include <sal/config.hpp>
+#include <algorithm>
+#include <array>
+#include <string>
+#include <vector>
+
+
+__sal_begin
+
+
+/**
+ * ptr_t represents contiguous region of raw memory with specified size.
+ * Internally it is kept as pointer pair to beginning and one byte past
+ * end of region. Object of this class does not own pointed region. It is
+ * application responsibility to handle lifecycle of ptr_t and pointed
+ * region.
+ */
+class ptr_t
+{
+public:
+
+  ptr_t () = default;
+
+
+  /**
+   * Construct ptr_t pointing to \a region with \a size.
+   */
+  ptr_t (void *region, size_t size) noexcept
+    : begin_(static_cast<char *>(region))
+    , end_(begin_ + size)
+  {}
+
+
+  /**
+   * Return raw pointer to beginning of region.
+   */
+  void *get () const noexcept
+  {
+    return begin_;
+  }
+
+
+  /**
+   * Return size of region
+   */
+  size_t size () const noexcept
+  {
+    return end_ - begin_;
+  }
+
+
+  /**
+   * Move beginning of pointed region by \a s bytes toward end of region.
+   */
+  ptr_t &operator+= (size_t s) noexcept
+  {
+    begin_ += s;
+    if (begin_ + s > end_)
+    {
+      begin_ = end_;
+    }
+    return *this;
+  }
+
+
+private:
+
+  char *begin_{}, * const end_{};
+};
+
+
+/**
+ * Create and return new ptr from \a p with beginning of region moved
+ * toward end by \a n bytes.
+ */
+inline ptr_t operator+ (const ptr_t &p, size_t n) noexcept
+{
+  auto r = p;
+  r += n;
+  return r;
+}
+
+
+/**
+ * Create and return new ptr from \a p with beginning of region moved
+ * toward end by \a n bytes.
+ */
+inline ptr_t operator+ (size_t n, const ptr_t &p) noexcept
+{
+  auto r = p;
+  r += n;
+  return r;
+}
+
+
+/**
+ * Construct ptr_t pointing to \a region with \a size.
+ */
+inline ptr_t ptr (void *region, size_t size) noexcept
+{
+  return ptr_t(region, size);
+}
+
+
+/**
+ * Construct new ptr_t as copy of \a ptr.
+ */
+inline ptr_t ptr (const ptr_t &ptr) noexcept
+{
+  return ptr_t(ptr.get(), ptr.size());
+}
+
+
+/**
+ * Construct new ptr_t as copy of \a ptr with up \a max_bytes.
+ */
+inline ptr_t ptr (const ptr_t &ptr, size_t max_bytes) noexcept
+{
+  return ptr_t(ptr.get(), (std::min)(max_bytes, ptr.size()));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data.
+ */
+template <typename T, size_t N>
+inline ptr_t ptr (T (&data)[N]) noexcept
+{
+  return ptr_t(data, N * sizeof(T));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data.
+ */
+template <typename T, size_t N>
+inline ptr_t ptr (std::array<T, N> &data) noexcept
+{
+  return ptr_t(data.data(), data.size() * sizeof(T));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data. Returned object is
+ * invalidated by any vector operation that invalidates all references,
+ * pointers and iterators referring to the elements in the sequence.
+ */
+template <typename T, typename Allocator>
+inline ptr_t ptr (std::vector<T, Allocator> &data) noexcept
+{
+  return ptr_t(data.data(), data.size() * sizeof(T));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data. Returned object is
+ * invalidated by any string operation that invalidates all references,
+ * pointers and iterators referring to the elements in the sequence.
+ */
+template <typename T, typename Traits, typename Allocator>
+inline ptr_t ptr (std::basic_string<T, Traits, Allocator> &data)
+  noexcept
+{
+  return ptr_t(&data[0], data.size() * sizeof(T));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, size_t N>
+inline ptr_t ptr (T (&data)[N], size_t max_bytes) noexcept
+{
+  return ptr_t(data, (std::min)(max_bytes, N * sizeof(T)));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, size_t N>
+inline ptr_t ptr (std::array<T, N> &data, size_t max_bytes) noexcept
+{
+  return ptr_t(data.data(), (std::min)(max_bytes, data.size() * sizeof(T)));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, typename Allocator>
+inline ptr_t ptr (std::vector<T, Allocator> &data, size_t max_bytes)
+  noexcept
+{
+  return ptr_t(data.data(), (std::min)(max_bytes, data.size() * sizeof(T)));
+}
+
+
+/**
+ * Construct ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, typename Traits, typename Allocator>
+inline ptr_t ptr (std::basic_string<T, Traits, Allocator> &data,
+  size_t max_bytes) noexcept
+{
+  return ptr_t(&data[0], (std::min)(max_bytes, data.size() * sizeof(T)));
+}
+
+
+/**
+ * const_ptr_t represents contiguous region of raw memory with specified size.
+ * Internally it is kept as pointer pair to beginning and one byte past end of
+ * region. Object of this class does not own pointed region. It is application
+ * responsibility to handle lifecycle of ptr_t and pointed region.
+ */
+class const_ptr_t
+{
+public:
+
+  const_ptr_t () = default;
+
+
+  /**
+   * Construct const_ptr_t pointing to \a region with \a size.
+   */
+  const_ptr_t (const void *region, size_t size) noexcept
+    : begin_(static_cast<const char *>(region))
+    , end_(begin_ + size)
+  {}
+
+
+  /**
+   * Return pointer to beginning of region.
+   */
+  const void *get () const noexcept
+  {
+    return begin_;
+  }
+
+
+  /**
+   * Return size of region
+   */
+  size_t size () const noexcept
+  {
+    return end_ - begin_;
+  }
+
+
+  /**
+   * Move beginning of pointed region by \a s bytes toward end of region.
+   */
+  const_ptr_t &operator+= (size_t s) noexcept
+  {
+    begin_ += s;
+    if (begin_ > end_)
+    {
+      begin_ = end_;
+    }
+    return *this;
+  }
+
+
+private:
+
+  const char *begin_{}, * const end_{};
+};
+
+
+/**
+ * Create and return new ptr from \a p with beginning of region moved
+ * toward end by \a n bytes.
+ */
+inline const_ptr_t operator+ (const const_ptr_t &p, size_t n) noexcept
+{
+  auto r = p;
+  r += n;
+  return r;
+}
+
+
+/**
+ * Create and return new ptr from \a p with beginning of region moved
+ * toward end by \a n bytes.
+ */
+inline const_ptr_t operator+ (size_t n, const const_ptr_t &p) noexcept
+{
+  auto r = p;
+  r += n;
+  return r;
+}
+
+
+/**
+ * Construct const_ptr_t pointing to \a region with \a size.
+ */
+inline const_ptr_t ptr (const void *region, size_t size) noexcept
+{
+  return const_ptr_t(region, size);
+}
+
+
+/**
+ * Construct new const_ptr_t as copy of \a ptr.
+ */
+inline const_ptr_t ptr (const const_ptr_t &ptr) noexcept
+{
+  return const_ptr_t(ptr.get(), ptr.size());
+}
+
+
+/**
+ * Construct new const_ptr_t as copy of \a ptr with up \a max_bytes.
+ */
+inline const_ptr_t ptr (const const_ptr_t &ptr, size_t max_bytes) noexcept
+{
+  return const_ptr_t(ptr.get(), (std::min)(max_bytes, ptr.size()));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data.
+ */
+template <typename T, size_t N>
+inline const_ptr_t ptr (const T (&data)[N]) noexcept
+{
+  return const_ptr_t(data, N * sizeof(T));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data.
+ */
+template <typename T, size_t N>
+inline const_ptr_t ptr (const std::array<T, N> &data) noexcept
+{
+  return const_ptr_t(data.data(), data.size() * sizeof(T));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data. Returned object is
+ * invalidated by any vector operation that invalidates all references,
+ * pointers and iterators referring to the elements in the sequence.
+ */
+template <typename T, typename Allocator>
+inline const_ptr_t ptr (const std::vector<T, Allocator> &data) noexcept
+{
+  return const_ptr_t(data.data(), data.size() * sizeof(T));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data. Returned object is
+ * invalidated by any string operation that invalidates all references,
+ * pointers and iterators referring to the elements in the sequence.
+ */
+template <typename T, typename Traits, typename Allocator>
+inline const_ptr_t ptr (const std::basic_string<T, Traits, Allocator> &data)
+  noexcept
+{
+  return const_ptr_t(&data[0], data.size() * sizeof(T));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, size_t N>
+inline const_ptr_t ptr (const T (&data)[N], size_t max_bytes) noexcept
+{
+  return const_ptr_t(data, (std::min)(max_bytes, N * sizeof(T)));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, size_t N>
+inline const_ptr_t ptr (const std::array<T, N> &data, size_t max_bytes) noexcept
+{
+  return const_ptr_t(data.data(), (std::min)(max_bytes, data.size() * sizeof(T)));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, typename Allocator>
+inline const_ptr_t ptr (const std::vector<T, Allocator> &data, size_t max_bytes)
+  noexcept
+{
+  return const_ptr_t(data.data(), (std::min)(max_bytes, data.size() * sizeof(T)));
+}
+
+
+/**
+ * Construct const_ptr_t using region owned by \a data but not more than
+ * \a max_bytes.
+ */
+template <typename T, typename Traits, typename Allocator>
+inline const_ptr_t ptr (const std::basic_string<T, Traits, Allocator> &data,
+  size_t max_bytes) noexcept
+{
+  return const_ptr_t(&data[0], (std::min)(max_bytes, data.size() * sizeof(T)));
+}
+
+
+__sal_end

--- a/sal/ptr.test.cpp
+++ b/sal/ptr.test.cpp
@@ -1,0 +1,408 @@
+#include <sal/ptr.hpp>
+#include <sal/common.test.hpp>
+
+
+namespace {
+
+
+constexpr size_t size = 4;
+
+
+template <typename T>
+auto *pointer (const sal::ptr_t &) noexcept //{{{1
+{
+  static T data_[size] = {};
+  return &data_[0];
+}
+
+
+template <typename T>
+auto *pointer (const sal::const_ptr_t &) noexcept //{{{1
+{
+  static const T data_[size] = {};
+  return &data_[0];
+}
+
+
+template <typename T>
+auto &array (const sal::ptr_t &) noexcept //{{{1
+{
+  static T data_[size] = {};
+  return data_;
+}
+
+
+template <typename T>
+auto &array (const sal::const_ptr_t &) noexcept //{{{1
+{
+  static const T data_[size] = {};
+  return data_;
+}
+
+
+template <typename T>
+auto &std_array (const sal::ptr_t &) noexcept //{{{1
+{
+  static std::array<T, size> data_{};
+  return data_;
+}
+
+
+template <typename T>
+auto &std_array (const sal::const_ptr_t &) noexcept //{{{1
+{
+  static const std::array<T, size> data_{};
+  return data_;
+}
+
+
+template <typename T>
+auto &std_vector (const sal::ptr_t &) noexcept //{{{1
+{
+  static std::vector<T> data_(size);
+  return data_;
+}
+
+
+template <typename T>
+auto &std_vector (const sal::const_ptr_t &) noexcept //{{{1
+{
+  static const std::vector<T> data_(size);
+  return data_;
+}
+
+
+auto &string (const sal::ptr_t &) //{{{1
+{
+  static std::string data_{"test"};
+  return data_;
+}
+
+
+auto &string (const sal::const_ptr_t &) //{{{1
+{
+  static const std::string data_{"test"};
+  return data_;
+}
+
+
+template <typename BufferType>
+using ptr = sal_test::with_type<BufferType>;
+
+
+using ptr_types = testing::Types<
+  sal::ptr_t,
+  sal::const_ptr_t
+>;
+
+TYPED_TEST_CASE(ptr, ptr_types);
+
+
+TYPED_TEST(ptr, ctor) //{{{1
+{
+  TypeParam ptr;
+  EXPECT_EQ(nullptr, ptr.get());
+  EXPECT_EQ(0U, ptr.size());
+}
+
+
+TYPED_TEST(ptr, ctor_pointer) //{{{1
+{
+  TypeParam ptr(pointer<char>(TypeParam()), size);
+  EXPECT_EQ(pointer<char>(TypeParam()), ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, inc) //{{{1
+{
+  TypeParam ptr(pointer<char>(TypeParam()), size);
+  ptr += size / 2;
+  EXPECT_EQ(pointer<char>(TypeParam()) + 2, ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, inc_invalid) //{{{1
+{
+  TypeParam ptr(pointer<char>(TypeParam()), size);
+  ptr += size * 2;
+  EXPECT_EQ(pointer<char>(TypeParam()) + size, ptr.get());
+  EXPECT_EQ(0U, ptr.size());
+}
+
+
+TYPED_TEST(ptr, add_ptr_and_size) //{{{1
+{
+  TypeParam a(pointer<char>(TypeParam()), size);
+  TypeParam b = a + 2;
+  EXPECT_EQ(pointer<char>(TypeParam()) + 2, b.get());
+  EXPECT_EQ(size / 2, b.size());
+}
+
+
+TYPED_TEST(ptr, add_ptr_and_size_invalid) //{{{1
+{
+  TypeParam a(pointer<char>(TypeParam()), size);
+  TypeParam b = a + 2 * size;
+  EXPECT_EQ(pointer<char>(TypeParam()) + size, b.get());
+  EXPECT_EQ(0U, b.size());
+}
+
+
+TYPED_TEST(ptr, add_size_and_ptr) //{{{1
+{
+  TypeParam a(pointer<char>(TypeParam()), size);
+  TypeParam b = 2 + a;
+  EXPECT_EQ(pointer<char>(TypeParam()) + 2, b.get());
+  EXPECT_EQ(size / 2, b.size());
+}
+
+
+TYPED_TEST(ptr, add_size_and_ptr_invalid) //{{{1
+{
+  TypeParam a(pointer<char>(TypeParam()), size);
+  TypeParam b = 2 * size + a;
+  EXPECT_EQ(pointer<char>(TypeParam()) + size, b.get());
+  EXPECT_EQ(0U, b.size());
+}
+
+
+TYPED_TEST(ptr, from_char_pointer) //{{{1
+{
+  auto *d = pointer<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_int_pointer) //{{{1
+{
+  auto *d = pointer<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_ptr) //{{{1
+{
+  auto &d = array<char>(TypeParam());
+  TypeParam a = sal::ptr(d);
+  TypeParam ptr = sal::ptr(a);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_ptr_half) //{{{1
+{
+  auto &d = array<char>(TypeParam());
+  TypeParam a = sal::ptr(d);
+  TypeParam ptr = sal::ptr(a, a.size() / 2);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_ptr_overflow) //{{{1
+{
+  auto &d = array<char>(TypeParam());
+  TypeParam a = sal::ptr(d);
+  TypeParam ptr = sal::ptr(a, a.size() * 2);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_char_array) //{{{1
+{
+  auto &d = array<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_char_array_half) //{{{1
+{
+  auto &d = array<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size / 2);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_char_array_overflow) //{{{1
+{
+  auto &d = array<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size * 1024);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_int_array) //{{{1
+{
+  auto &d = array<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size * sizeof(int), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_int_array_half) //{{{1
+{
+  auto &d = array<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size / 2);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_int_array_overflow) //{{{1
+{
+  auto &d = array<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size * 1024);
+  EXPECT_EQ(d, ptr.get());
+  EXPECT_EQ(size * sizeof(int), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_char_array) //{{{1
+{
+  auto &d = std_array<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(d.size(), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_char_array_half) //{{{1
+{
+  auto &d = std_array<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size / 2);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_char_array_overflow) //{{{1
+{
+  auto &d = std_array<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size * 1024);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_int_array) //{{{1
+{
+  auto &d = std_array<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(d.size() * sizeof(int), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_int_array_half) //{{{1
+{
+  auto &d = std_array<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size / 2);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_int_array_overflow) //{{{1
+{
+  auto &d = std_array<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size * 1024);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size * sizeof(int), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_char_vector) //{{{1
+{
+  auto &d = std_vector<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(d.size(), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_char_vector_half) //{{{1
+{
+  auto &d = std_vector<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size / 2);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_char_vector_overflow) //{{{1
+{
+  auto &d = std_vector<char>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size * 1024);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_int_vector) //{{{1
+{
+  auto &d = std_vector<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(d.size() * sizeof(int), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_int_vector_half) //{{{1
+{
+  auto &d = std_vector<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size / 2);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_std_int_vector_overflow) //{{{1
+{
+  auto &d = std_vector<int>(TypeParam());
+  TypeParam ptr = sal::ptr(d, size * 1024);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size * sizeof(int), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_string) //{{{1
+{
+  auto &d = string(TypeParam());
+  TypeParam ptr = sal::ptr(d);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(d.size(), ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_string_half) //{{{1
+{
+  auto &d = string(TypeParam());
+  TypeParam ptr = sal::ptr(d, size / 2);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(size / 2, ptr.size());
+}
+
+
+TYPED_TEST(ptr, from_string_overflow) //{{{1
+{
+  auto &d = string(TypeParam());
+  TypeParam ptr = sal::ptr(d, size * 1024);
+  EXPECT_EQ(d.data(), ptr.get());
+  EXPECT_EQ(d.size(), ptr.size());
+}
+
+
+} // namespace


### PR DESCRIPTION
Use sal::ptr instead of explicit raw pointer/size pair for socket send/recv methods